### PR TITLE
Editor: Fix division assignment in factor offset function

### DIFF
--- a/scripts/data/chart/rubichart_editor_functions.gd
+++ b/scripts/data/chart/rubichart_editor_functions.gd
@@ -13,7 +13,7 @@ static func factor_offset_and_quant(values : Array) -> void:
 			continue
 		
 		values[0] /= cur_quant
-		values[1] = cur_quant
+		values[1] /= cur_quant
 		break
 
 static func chart_add_note_start(chart : RubiChart, note : RubiChartNote, measure : int, offset : int, quant : RubiChart.Quant) -> void:


### PR DESCRIPTION
just added a "/" in the assignment to properly divide the variables